### PR TITLE
Add a tag to prevent the include of ros2_control

### DIFF
--- a/robots/panda_arm.urdf.xacro
+++ b/robots/panda_arm.urdf.xacro
@@ -1,7 +1,8 @@
 <?xml version='1.0' ?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
-    <xacro:arg name="load_gazebo" default="false"/>
     <xacro:arg name="prefix" default="panda_"/>
+    <xacro:arg name="load_gazebo" default="false"/>
+    <xacro:arg name="load_ros2_control" default="false"/>
     <xacro:arg name="use_sim" default="false"/>
     <xacro:arg name="connected_to" default=""/>
     <xacro:arg name="xyz" default="0 0 0"/>
@@ -19,5 +20,7 @@
         <xacro:panda_arm prefix="$(arg prefix)" connected_to="$(arg connected_to)" xyz="$(arg xyz)" rpy="$(arg rpy)"/>
     </xacro:unless>
 
-    <xacro:panda_arm_interface name="PandaInterface" prefix="$(arg prefix)" use_sim="$(arg use_sim)"/>
+    <xacro:if value="$(arg load_ros2_control)">
+        <xacro:panda_arm_interface name="PandaInterface" prefix="$(arg prefix)" use_sim="$(arg use_sim)"/>
+    </xacro:if>
 </robot>


### PR DESCRIPTION
As the pybullet simulator part can't handle the `ros2_control` tag in the URDF, this PR encapsulate that into a conditional tag to prevent the inclusion.