### PR TITLE
Add communication parameters in the URDF

### DIFF
--- a/robots/panda_arm.urdf.xacro
+++ b/robots/panda_arm.urdf.xacro
@@ -1,6 +1,9 @@
 <?xml version='1.0' ?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
     <xacro:arg name="prefix" default="panda_"/>
+    <xacro:arg name="robot_ip" default="127.0.0.1"/>
+    <xacro:arg name="robot_state_port" default="1601"/>
+    <xacro:arg name="robot_command_port" default="1602"/>
     <xacro:arg name="load_gazebo" default="false"/>
     <xacro:arg name="load_ros2_control" default="false"/>
     <xacro:arg name="use_sim" default="false"/>
@@ -21,6 +24,13 @@
     </xacro:unless>
 
     <xacro:if value="$(arg load_ros2_control)">
-        <xacro:panda_arm_interface name="PandaInterface" prefix="$(arg prefix)" use_sim="$(arg use_sim)"/>
+        <xacro:panda_arm_interface
+                name="PandaInterface"
+                prefix="$(arg prefix)"
+                robot_ip="$(arg robot_ip)"
+                robot_state_port="$(arg robot_state_port)"
+                robot_command_port="$(arg robot_command_port)"
+                use_sim="$(arg use_sim)"
+        />
     </xacro:if>
 </robot>

--- a/ros2_control/panda_arm.ros2_control.xacro
+++ b/ros2_control/panda_arm.ros2_control.xacro
@@ -1,16 +1,22 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="panda_arm_interface" params="name prefix use_sim:=^|false">
+  <xacro:macro name="panda_arm_interface" params="name prefix robot_ip robot_state_port robot_command_port use_sim">
 
     <ros2_control name="${name}" type="system">
-      <xacro:if value="$(arg use_sim)">
+      <xacro:if value="${use_sim}">
         <hardware>
           <plugin>robot_interface/simulators/PybulletInterface</plugin>
+          <param name="robot_ip">${robot_ip}</param>
+          <param name="robot_state_port">${robot_state_port}</param>
+          <param name="robot_command_port">${robot_command_port}</param>
         </hardware>
       </xacro:if>
-      <xacro:unless value="$(arg use_sim)">
+      <xacro:unless value="${use_sim}">
         <hardware>
           <plugin>robot_interface/franka/PandaInterface</plugin>
+          <param name="robot_ip">${robot_ip}</param>
+          <param name="robot_state_port">${robot_state_port}</param>
+          <param name="robot_command_port">"${robot_command_port}</param>
         </hardware>
       </xacro:unless>
 

--- a/ros2_control/panda_arm.ros2_control.xacro
+++ b/ros2_control/panda_arm.ros2_control.xacro
@@ -16,7 +16,7 @@
           <plugin>robot_interface/franka/PandaInterface</plugin>
           <param name="robot_ip">${robot_ip}</param>
           <param name="robot_state_port">${robot_state_port}</param>
-          <param name="robot_command_port">"${robot_command_port}</param>
+          <param name="robot_command_port">${robot_command_port}</param>
         </hardware>
       </xacro:unless>
 


### PR DESCRIPTION
This PR adds the robot ip address and ports in the URDF for communication with both the real robot and the simulator. This is the only way to pass those parameters to the hardware interface.